### PR TITLE
Added approximate/correct adders exploration by Stefania Preatto

### DIFF
--- a/RTL/filters_and_routing/README_approx.txt
+++ b/RTL/filters_and_routing/README_approx.txt
@@ -1,0 +1,15 @@
+Chroma Legacy:	- filter_chroma_reconfigurable_stage2_LF_Correct 
+			- Ladner_Fisher_Correct_Adder_Nbits
+				- ParalPrefix_Unit
+				- GP_Unit
+
+Luma Legacy:	- filter_reconfigurable_stage2_GeAr
+			- GeAr_Adder_Nbits_P0_3Blocks
+
+Luma Approximate: - filter_reconfigurable_stage2_HC_Correct
+		  - filter_reconfigurable_3tap_stage2_HC_Correct
+		  - filter_reconfigurable_5tap_stage2_HC_Correct
+			- Han_Carlson_Correct_Adder_Nbits
+				- ParalPrefix_Unit
+				- GP_Unit
+				

--- a/RTL/filters_and_routing/adders/GP_Unit.vhd
+++ b/RTL/filters_and_routing/adders/GP_Unit.vhd
@@ -1,0 +1,41 @@
+-- Copyright 2018 Stefania Preatto.
+-- Copyright and related rights are licensed under the Solderpad Hardware
+-- License, Version 0.51 (the “License”); you may not use this file except in
+-- compliance with the License.  You may obtain a copy of the License at
+-- http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+-- or agreed to in writing, software, hardware and materials distributed under
+-- this License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+----------------------------------------------------------------------------------
+-- Author: Stefania Preatto 
+-- 
+-- Create Date(mm/aaaa):	04/2018 
+-- Module Name:				GP_Unit.vhd
+-- Project:					interpolation filter project for HEVC
+-- Description:				Parallel_Prefix_Adders
+-- Dependencies:			none
+--			
+-- Revision: 
+--		1.0 created
+----------------------------------------------------------------------------------
+
+library IEEE;
+use IEEE.std_logic_1164.all;
+use IEEE.numeric_std.all;
+
+entity GP_Unit is
+	port(
+		A,B				:IN std_logic;	 -- adder inputs
+		G,P				:OUT std_logic  -- generate and propagate output
+	);
+end entity GP_Unit;
+
+architecture structure of GP_Unit is
+
+begin
+	
+	G <= A AND B;
+	P <= A XOR B;
+	
+end structure;

--- a/RTL/filters_and_routing/adders/GeAr_Adder_Nbits_P0_3Blocks.vhd
+++ b/RTL/filters_and_routing/adders/GeAr_Adder_Nbits_P0_3Blocks.vhd
@@ -1,0 +1,84 @@
+-- Copyright 2018 Stefania Preatto.
+-- Copyright and related rights are licensed under the Solderpad Hardware
+-- License, Version 0.51 (the \u201cLicense\u201d); you may not use this file except in
+-- compliance with the License.  You may obtain a copy of the License at
+-- http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+-- or agreed to in writing, software, hardware and materials distributed under
+-- this License is distributed on an \u201cAS IS\u201d BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+----------------------------------------------------------------------------------
+-- Author: Stefania Preatto 
+-- 
+-- Create Date(mm/aaaa):	05/2018 
+-- Module Name:			GeAr_Adder_Nbits.vhd
+-- Project:				interpolation filter project for HEVC
+-- Description:			Generic Accuracy Reconfigurable Adder of Nbits
+-- Dependencies:		
+--					none
+--					
+-- Revision: 
+--		1.0 created
+----------------------------------------------------------------------------------
+library IEEE;
+use IEEE.std_logic_1164.all;
+use IEEE.numeric_std.all;
+entity GeAr_Adder_Nbits is
+	generic(N:integer:=22; R:integer:=7; P:integer:=0); -- L=R+P, N=R+L
+	port(
+		In1, In2			:IN std_logic_vector(N-1 downto 0);	-- adder inputs
+		c_in,c_in1			:IN std_logic;
+		c_out,c_out1		:OUT std_logic;
+		out_A				:OUT std_logic_vector(N-1 downto 0)  -- adder output
+	);
+end entity GeAr_Adder_Nbits;
+
+architecture structural of GeAr_Adder_Nbits is
+
+--signals
+signal temp 						: std_logic_vector(N-1 downto 2*R+P-1);
+signal temp1						: std_logic_vector(2*R+P downto R+P-1);  --it includes carry-in and carry-out to be used
+signal sum1_MSB						: std_logic_vector(N-1 downto 2*R+P);
+signal sum1_middle					: std_logic_vector(2*R+P-1 downto R+P);
+signal cg_o, cp_o,cg_o1, cp_o1		: std_logic;
+signal ED,ED1						: std_logic;
+signal sum1_LSB						: std_logic_vector(R+P downto 0); --it includes carry-out to be used
+begin
+
+
+----BLOCK 1: MSBs------------------------
+--SUM for Most Significant Bits 
+temp <= std_logic_vector(signed(In1(N-1 downto 2*R+P)&'1')+signed(In2(N-1 downto 2*R+P)&cg_o));
+sum1_MSB <= temp(N-1 downto 2*R+P);
+
+--carry generation for Most Significant block with CG Unit
+cg_o <= (In1(2*R+P-1) and In2(2*R+P-1)) or (c_in and (In1(2*R+P-1) xor In2(2*R+P-1)));
+cp_o <= In1(2*R+P-1) xor In2(2*R+P-1);
+
+--Error detection for c_in unit
+ED <= (temp1(2*R+P) xor c_in) AND cp_o;
+c_out <= c_in xor ED;
+
+-----BLOCK 2: middle bits---------------------
+--SUM for intermediate Bits 
+temp1 <= std_logic_vector(signed('0'&In1(2*R+P-1 downto R+P)&'1')+signed('0'&In2(2*R+P-1 downto R+P)&cg_o1)); --temp1(2R+P)=carry out
+sum1_middle <= temp1(2*R+P-1 downto R+P); 
+
+--carry generation for Most Significant block with CG Unit
+cg_o1 <= (In1(R+P-1) and In2(R+P-1)) or (c_in1 and (In1(R+P-1) xor In2(R+P-1)));
+cp_o1 <= In1(R+P-1) xor In2(R+P-1);
+
+--Error detection for c_in unit				
+ED1 <= (sum1_LSB(R+P) xor c_in1) AND cp_o1;
+c_out1 <= c_in1 xor ED1;
+
+
+----BLOCK 3: LSBs------------------------
+--SUM for Least Significant Bits
+sum1_LSB <= std_logic_vector(signed('0'&In1(R+P-1 downto 0)) + signed('0'&In2(R+P-1 downto 0))); --sum1_LSB(R+P)=c_out, sum1_LSB(R+P-1:0)=out_A(R+P-1:0)
+
+
+--sum out is composed of outcomes of the three sub-blocks
+out_A <= sum1_MSB(N-1 downto 2*R+P)&sum1_middle(2*R+P-1 downto R+P)&sum1_LSB(R+P-1 downto 0);
+
+end structural;

--- a/RTL/filters_and_routing/adders/Han_Carlson_Correct_Adder_Nbits.vhd
+++ b/RTL/filters_and_routing/adders/Han_Carlson_Correct_Adder_Nbits.vhd
@@ -1,0 +1,181 @@
+-- Copyright 2018 Stefania Preatto.
+-- Copyright and related rights are licensed under the Solderpad Hardware
+-- License, Version 0.51 (the “License”); you may not use this file except in
+-- compliance with the License.  You may obtain a copy of the License at
+-- http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+-- or agreed to in writing, software, hardware and materials distributed under
+-- this License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+----------------------------------------------------------------------------------
+-- Author: Stefania Preatto 
+-- 
+-- Create Date(mm/aaaa):	04/2018 
+-- Module Name:			Han_Carlson_Correct_Adder_Nbits.vhd
+-- Project:				interpolation filter project for HEVC
+-- Description:			Adder in speculative approach
+-- Dependencies:		GP_Unit	
+--						ParalPrefix_Unit
+-- Revision: 
+--		1.0 created
+----------------------------------------------------------------------------------
+library IEEE;
+use IEEE.std_logic_1164.all;
+use IEEE.numeric_std.all;
+entity Han_Carlson_Correct_Adder_Nbits is
+	generic(N:positive:=22);
+	port(
+		In1, In2			:IN std_logic_vector(N-1 downto 0);	-- adder inputs
+		out_A				:OUT std_logic_vector(N-1 downto 0)  -- adder output
+	);
+end entity Han_Carlson_Correct_Adder_Nbits;
+
+architecture structural of Han_Carlson_Correct_Adder_Nbits is
+
+component GP_Unit is
+	port(
+		A,B				:IN std_logic;	
+		G,P				:OUT std_logic  
+	);
+end component;
+
+component ParalPrefix_Unit is
+	port(
+		G1,G0,P1,P0		:IN std_logic;	
+		G01,P01			:OUT std_logic  
+	);
+end component ParalPrefix_Unit;
+
+signal gen_bits, prop_bits	: std_logic_vector(N-1 DOWNTO 0);
+signal G_s1, P_s1				: std_logic_vector(N/2-1 downto 0);
+signal G_s2, P_s2				: std_logic_vector(N/2-2 downto 0);
+signal G_s3, P_s3				: std_logic_vector(N/2-3 downto 0);
+signal G_s4, P_s4				: std_logic_vector(N/2-5 downto 0);
+signal G_s5, P_s5				: std_logic_vector(N/2-9 downto 0);
+signal G_s6, P_s6				: std_logic_vector(N-1 downto 0);
+signal c_i_min1				: std_logic_vector(N-1 downto 0);
+
+begin
+	
+	-- BLOCK 1: gi,pi GENERATION
+	gp_gen: for i in N-1 downto 0 generate
+			GP_U: GP_Unit port map(A=>In1(i), B=>In2(i), G=>gen_bits(i), P=>prop_bits(i));
+	end generate gp_gen;
+	
+	---------------------------------------------
+	--BLOCK 2: parallel & prefix problem with Han-Carlson Architecture
+	
+	--outer row: Brent&Kung architecture
+	PP0_s1: for i in 1 to N/2 generate
+			PP0_U1: ParalPrefix_Unit port map(G1=>gen_bits(2*i-1),G0=>gen_bits(2*i-2),P1=>prop_bits(2*i-1),P0=>prop_bits(2*i-2),G01=>G_s1(i-1),P01=>P_s1(i-1));
+	end generate PP0_s1;
+	
+	--inner rows: Kogge-Stone architecture
+	PP0_s2: for i in 1 to N/2-1 generate
+			PP0_U2: ParalPrefix_Unit port map(G1=>G_s1(i),G0=>G_s1(i-1),P1=>P_s1(i),P0=>P_s1(i-1),G01=>G_s2(i-1),P01=>P_s2(i-1));
+	end generate PP0_s2;
+	
+	PP0_S3: for i in 1 to N/2-2 generate
+	
+			middleBit_s3: if i>1 AND i<=N/2-2 generate
+			PP0_U3: ParalPrefix_Unit port map(G1=>G_s2(i),G0=>G_s2(i-2),P1=>P_s2(i),P0=>P_s2(i-2),G01=>G_s3(i-1),P01=>P_s3(i-1));
+			END generate middleBit_s3;
+			
+			LSBs_s3: if i=1 generate
+			PP0_U3: ParalPrefix_Unit port map(G1=>G_s2(i),G0=>G_s1(i-1),P1=>P_s2(i),P0=>P_s1(i-1),G01=>G_s3(i-1),P01=>P_s3(i-1));
+			END generate LSBs_s3;
+			
+	end generate PP0_s3;
+	
+	
+	PP0_s4: for i in 1 to N/2-4 generate
+	
+			middleBit_s4: if i>2 AND i<=N/2-4 generate
+			PP0_U4: ParalPrefix_Unit port map(G1=>G_s3(i+1),G0=>G_s3(i-3),P1=>P_s3(i+1),P0=>P_s3(i-3),G01=>G_s4(i-1),P01=>P_s4(i-1));
+			END generate middleBit_s4;
+			
+			LSB1_s4: if i=2 generate
+			PP0_U4: ParalPrefix_Unit port map(G1=>G_s3(i+1),G0=>G_s2(i-2),P1=>P_s3(i+1),P0=>P_s2(i-2),G01=>G_s4(i-1),P01=>P_s4(i-1));
+			END generate LSB1_s4;
+	
+			LSB0_s4: if i=1 generate
+			PP0_U4: ParalPrefix_Unit port map(G1=>G_s3(i+1),G0=>G_s1(i-1),P1=>P_s3(i+1),P0=>P_s1(i-1),G01=>G_s4(i-1),P01=>P_s4(i-1));
+			END generate LSB0_s4;
+	
+	end generate PP0_s4;
+	
+			
+	PP0_s5: for i in 1 to N/2-8 generate
+			
+			middleBit_s5: if i>=3 AND i<=N/2-8 generate
+			PP0_U5: ParalPrefix_Unit port map(G1=>G_s4(i+3),G0=>G_s3(i-3),P1=>P_s4(i+3),P0=>P_s3(i-3),G01=>G_s5(i-1),P01=>P_s5(i-1));
+			END generate middleBit_s5;
+			
+			LSB1_s5: if i=2 generate
+			PP0_U5: ParalPrefix_Unit port map(G1=>G_s4(i+3),G0=>G_s2(i-2),P1=>P_s4(i+3),P0=>P_s2(i-2),G01=>G_s5(i-1),P01=>P_s5(i-1));
+			END generate LSB1_s5;
+			
+			LSB0_s5: if i=1 generate
+			PP0_U5: ParalPrefix_Unit port map(G1=>G_s4(i+3),G0=>G_s1(i-1),P1=>P_s4(i+3),P0=>P_s1(i-1),G01=>G_s5(i-1),P01=>P_s5(i-1));
+			END generate LSB0_s5;
+	
+	end generate PP0_s5;
+
+	--final row: Brent&Kung architecture
+	
+	PP0_s6: for i in 1 to N/2 generate
+			
+			MSB_odd: if i=N/2 generate
+			G_s6(2*i-1) <= G_s5(i-9);
+			P_s6(2*i-1) <= P_s5(i-9);
+			END generate;
+			
+			MSB_s6: if i>8 AND i<=N/2-1 generate
+			PP0_U6: ParalPrefix_Unit port map(G1=>gen_bits(2*i),G0=>G_s5(i-9),P1=>prop_bits(2*i),P0=>P_s5(i-9),G01=>G_s6(2*i),P01=>P_s6(2*i));
+			G_s6(2*i-1) <= G_s5(i-9);
+			P_s6(2*i-1) <= P_s5(i-9);
+			END generate MSB_s6;
+			
+			middle_s6_s4: if i>4 AND i<=8 generate
+			PP0_U6: ParalPrefix_Unit port map(G1=>gen_bits(2*i),G0=>G_s4(i-5),P1=>prop_bits(2*i),P0=>P_s4(i-5),G01=>G_s6(2*i),P01=>P_s6(2*i));
+			G_s6(2*i-1) <= G_s4(i-5);
+			P_s6(2*i-1) <= P_s4(i-5);
+			END generate middle_s6_s4;
+			
+			middle_s6_s3: if i>2 AND i<=4 generate
+			PP0_U6: ParalPrefix_Unit port map(G1=>gen_bits(2*i),G0=>G_s3(i-3),P1=>prop_bits(2*i),P0=>P_s3(i-3),G01=>G_s6(2*i),P01=>P_s6(2*i));
+			G_s6(2*i-1) <= G_s3(i-3);
+			P_s6(2*i-1) <= P_s3(i-3);
+			END generate middle_s6_s3;
+			
+			middle_s6_s2: if i=2 generate
+			PP0_U6: ParalPrefix_Unit port map(G1=>gen_bits(2*i),G0=>G_s2(i-2),P1=>prop_bits(2*i),P0=>P_s2(i-2),G01=>G_s6(2*i),P01=>P_s6(2*i));
+			G_s6(2*i-1) <= G_s2(i-2);
+			P_s6(2*i-1) <= P_s2(i-2);
+			END generate middle_s6_s2;
+			
+			middle_s6_s1: if i=1 generate
+			PP0_U6: ParalPrefix_Unit port map(G1=>gen_bits(2*i),G0=>G_s1(i-1),P1=>prop_bits(2*i),P0=>P_s1(i-1),G01=>G_s6(2*i),P01=>P_s6(2*i));
+			G_s6(2*i-1) <= G_s1(i-1);
+			P_s6(2*i-1) <= P_s1(i-1);
+			G_s6(2*i-2) <= gen_bits(i-1); 
+			P_s6(2*i-2) <= prop_bits(i-1);		
+			END generate middle_s6_s1;
+			
+	end generate PP0_s6;
+	
+	------------------------------------
+	--BLOCK 3: Carry computation
+	c_i_min1(0) <= '0';
+	Cin_gen: for i in 1 to N-1 generate	
+		   c_i_min1(i) <= G_s6(i-1) OR (P_s6(i-1) AND c_i_min1(0)); --since c0=0 because we're just considering additions
+	end generate Cin_gen;
+	
+	------------------------------------
+	--BLOCK 4: Sum computation
+	Sum_gen: for i in 0 to N-1 generate
+			out_A(i) <= prop_bits(i) XOR c_i_min1(i);		
+	end generate Sum_gen;
+	
+	
+end structural;

--- a/RTL/filters_and_routing/adders/Ladner_Fisher_Correct_Adder_Nbits.vhd
+++ b/RTL/filters_and_routing/adders/Ladner_Fisher_Correct_Adder_Nbits.vhd
@@ -1,0 +1,210 @@
+-- Copyright 2018 Stefania Preatto.
+-- Copyright and related rights are licensed under the Solderpad Hardware
+-- License, Version 0.51 (the “License”); you may not use this file except in
+-- compliance with the License.  You may obtain a copy of the License at
+-- http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+-- or agreed to in writing, software, hardware and materials distributed under
+-- this License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+----------------------------------------------------------------------------------
+-- Author: Stefania Preatto 
+-- 
+-- Create Date(mm/aaaa):	04/2018 
+-- Module Name:			Ladner_Fisher_Correct_Adder_Nbits.vhd
+-- Project:			interpolation filter project for HEVC
+-- Description:			Adder in speculative approach
+-- Dependencies:	GP_Unit	
+--					ParalPrefix_Unit
+-- Revision: 
+--		1.0 created
+----------------------------------------------------------------------------------
+library IEEE;
+use IEEE.std_logic_1164.all;
+use IEEE.numeric_std.all;
+entity Ladner_Fisher_Nbit_correct is
+	generic(N:positive:=22);
+	port(
+		In1, In2			:IN std_logic_vector(N-1 downto 0);	-- adder inputs
+		out_A				:OUT std_logic_vector(N-1 downto 0)  -- adder output
+	);
+end entity Ladner_Fisher_Nbit_correct;
+
+architecture structural of Ladner_Fisher_Nbit_correct is
+
+component GP_Unit is
+	port(
+		A,B				:IN std_logic;	 
+		G,P				:OUT std_logic  
+	);
+end component;
+
+component ParalPrefix_Unit is
+	port(
+		G1,G0,P1,P0		:IN std_logic;	 
+		G01,P01			:OUT std_logic 
+	);
+end component ParalPrefix_Unit;
+
+signal gen_bits, prop_bits	: std_logic_vector(N-1 DOWNTO 0);
+signal G_s1, P_s1				: std_logic_vector(N/2-1 downto 0);
+signal G_s2, P_s2				: std_logic_vector(4 downto 0);
+signal G_s3, P_s3				: std_logic_vector(4 downto 0);
+signal G_s4, P_s4				: std_logic_vector(3 downto 0);
+signal G_s5, P_s5				: std_logic_vector(N/2-9 downto 0);
+signal G_s6, P_s6				: std_logic_vector(N-1 downto 0);
+signal c_i_min1				: std_logic_vector(N-1 downto 0);
+
+
+
+begin
+	
+	-- BLOCK 1: gi,pi GENERATION
+	gp_gen: for i in N-1 downto 0 generate
+			GP_U: GP_Unit port map(A=>In1(i), B=>In2(i), G=>gen_bits(i), P=>prop_bits(i));
+	end generate gp_gen;
+	
+	---------------------------------------------
+	--BLOCK 2: parallel & prefix problem with Ladner-Fisher Architecture
+	
+	-- first two rows: Brent&Kung architecture
+	PP0_s1: for i in 1 to N/2 generate
+			PP0_U1: ParalPrefix_Unit port map(G1=>gen_bits(2*i-1),G0=>gen_bits(2*i-2),P1=>prop_bits(2*i-1),P0=>prop_bits(2*i-2),G01=>G_s1(i-1),P01=>P_s1(i-1));
+	end generate PP0_s1;
+	
+	PP0_s2: for i in 0 to 4 generate 
+	
+			MSB_22_20_s2: if i=4 AND N/2>=10 generate
+					PP0_U2: ParalPrefix_Unit port map(G1=>G_s1(2*i+1),G0=>G_s1(2*i),P1=>P_s1(2*i+1),P0=>P_s1(2*i),G01=>G_s2(i),P01=>P_s2(i));
+			end generate MSB_22_20_s2;		
+			
+			MSB_18_s2: if i=4 AND N/2<10 generate
+					G_s2(i) <= '0';
+					P_s2(i) <= '0';
+			end generate MSB_18_s2;
+			
+			middleBit_s2: if i<4 generate
+					PP0_U2: ParalPrefix_Unit port map(G1=>G_s1(2*i+1),G0=>G_s1(2*i),P1=>P_s1(2*i+1),P0=>P_s1(2*i),G01=>G_s2(i),P01=>P_s2(i));
+			end generate middleBit_s2;
+			
+	end generate PP0_s2;
+	
+	-- inner rows: Ladner-Fisher architecture
+	
+	PP0_s3: for i in 0 to 4 generate
+	
+			MSBs_s3: if i=4 AND N/2=11 generate						-- for MSB of N/2=11 one more operator is needed
+			PP0_U3: ParalPrefix_Unit port map(G1=>G_s1(2*i+2),G0=>G_s2(i),P1=>P_s1(2*i+2),P0=>P_s2(i),G01=>G_s3(i),P01=>P_s3(i));
+			END generate MSBs_s3;
+			
+			MSB_18_s3: if i=4 AND N/2<11 generate
+					G_s3(i) <= '0';
+					P_s3(i) <= '0';
+			end generate MSB_18_s3;
+				
+			middleBitEven_s3: if ((i mod 2) = 0) AND i<=3 generate  		--for even numbers
+			PP0_U3: ParalPrefix_Unit port map(G1=>G_s1(2*i+2),G0=>G_s2(i),P1=>P_s1(2*i+2),P0=>P_s2(i),G01=>G_s3(i),P01=>P_s3(i));
+			END generate middleBitEven_s3;
+			
+			middleBitOdd_s3: if ((i mod 2) /= 0) AND i<=3 generate				--for odd numbers
+			PP0_U3: ParalPrefix_Unit port map(G1=>G_s2(i),G0=>G_s2(i-1),P1=>P_s2(i),P0=>P_s2(i-1),G01=>G_s3(i),P01=>P_s3(i));
+			END generate middleBitOdd_s3;
+			
+	end generate PP0_s3;
+	
+	
+	
+	PP0_s4: for i in 0 to 3 generate
+	
+			middleBit_s4: if i>1 AND i<=3 generate
+			PP0_U4: ParalPrefix_Unit port map(G1=>G_s3(i),G0=>G_s3(1),P1=>P_s3(i),P0=>P_s3(1),G01=>G_s4(i),P01=>P_s4(i));
+			END generate middleBit_s4;
+			
+			LSB1_s4: if i=1 generate
+			PP0_U4: ParalPrefix_Unit port map(G1=>G_s2(i+1),G0=>G_s3(1),P1=>P_s2(i+1),P0=>P_s3(1),G01=>G_s4(i),P01=>P_s4(i));
+			END generate LSB1_s4;
+	
+			LSB0_s4: if i=0 generate
+			PP0_U4: ParalPrefix_Unit port map(G1=>G_s1(i+4),G0=>G_s3(1),P1=>P_s1(i+4),P0=>P_s3(1),G01=>G_s4(i),P01=>P_s4(i));
+			END generate LSB0_s4;
+	
+	end generate PP0_s4;
+		
+	PP0_s5: for i in 0 to N/2-9 generate
+			
+			middleBit_s5: if i=2 generate
+			PP0_U5: ParalPrefix_Unit port map(G1=>G_s3(i+2),G0=>G_s4(3),P1=>P_s3(i+2),P0=>P_s4(3),G01=>G_s5(i),P01=>P_s5(i));
+			END generate middleBit_s5;
+			
+			LSB1_s5: if i=1 generate
+			PP0_U5: ParalPrefix_Unit port map(G1=>G_s2(i+3),G0=>G_s4(3),P1=>P_s2(i+3),P0=>P_s4(3),G01=>G_s5(i),P01=>P_s5(i));
+			END generate LSB1_s5;
+			
+			LSB0_s5: if i=0 generate
+			PP0_U5: ParalPrefix_Unit port map(G1=>G_s1(8),G0=>G_s4(3),P1=>P_s1(8),P0=>P_s4(3),G01=>G_s5(i),P01=>P_s5(i));
+			END generate LSB0_s5;
+	
+	end generate PP0_s5;
+	
+
+	--final row: Brent&Kung architecture
+	
+	PP0_s6: for i in 1 to N/2 generate
+			
+			MSB_odd: if i=N/2 generate
+			G_s6(2*i-1) <= G_s5(i-9);
+			P_s6(2*i-1) <= P_s5(i-9);
+			END generate;	
+			
+			MSB_s6: if i>8 AND i<=N/2-1 generate
+			PP0_U6: ParalPrefix_Unit port map(G1=>gen_bits(2*i),G0=>G_s5(i-9),P1=>prop_bits(2*i),P0=>P_s5(i-9),G01=>G_s6(2*i),P01=>P_s6(2*i));
+			G_s6(2*i-1) <= G_s5(i-9);
+			P_s6(2*i-1) <= P_s5(i-9);
+			END generate MSB_s6;
+
+			
+			middle_s6_s4: if i>4 AND i<=8 generate
+			PP0_U6: ParalPrefix_Unit port map(G1=>gen_bits(2*i),G0=>G_s4(i-5),P1=>prop_bits(2*i),P0=>P_s4(i-5),G01=>G_s6(2*i),P01=>P_s6(2*i));
+			G_s6(2*i-1) <= G_s4(i-5);
+			P_s6(2*i-1) <= P_s4(i-5);
+			END generate middle_s6_s4;
+			
+			
+			middle_s6_s3: if i>2 AND i<=4 generate
+			PP0_U6: ParalPrefix_Unit port map(G1=>gen_bits(2*i),G0=>G_s3(i-3),P1=>prop_bits(2*i),P0=>P_s3(i-3),G01=>G_s6(2*i),P01=>P_s6(2*i));
+			G_s6(2*i-1) <= G_s3(i-3);
+			P_s6(2*i-1) <= P_s3(i-3);
+			END generate middle_s6_s3;
+			
+			middle_s6_s2: if i=2 generate
+			PP0_U6: ParalPrefix_Unit port map(G1=>gen_bits(2*i),G0=>G_s2(i-2),P1=>prop_bits(2*i),P0=>P_s2(i-2),G01=>G_s6(2*i),P01=>P_s6(2*i));
+			G_s6(2*i-1) <= G_s2(i-2);
+			P_s6(2*i-1) <= P_s2(i-2);
+			END generate middle_s6_s2;
+			
+			middle_s6_s1: if i=1 generate
+			PP0_U6: ParalPrefix_Unit port map(G1=>gen_bits(2*i),G0=>G_s1(i-1),P1=>prop_bits(2*i),P0=>P_s1(i-1),G01=>G_s6(2*i),P01=>P_s6(2*i));
+			G_s6(2*i-1) <= G_s1(i-1);
+			P_s6(2*i-1) <= P_s1(i-1);
+			G_s6(2*i-2) <= gen_bits(i-1); 
+			P_s6(2*i-2) <= prop_bits(i-1);		
+			END generate middle_s6_s1;
+			
+	end generate PP0_s6;
+	
+	------------------------------------
+	--BLOCK 3: Carry computation
+	c_i_min1(0) <= '0';
+	Cin_gen: for i in 1 to N-1 generate
+			c_i_min1(i) <= G_s6(i-1); -- OR (P_s6(i-1) AND c_i_min1(0)); -- I can neglect the or gate due to addition c0=0
+	end generate Cin_gen;
+	
+	------------------------------------
+	--BLOCK 4: Sum computation
+	Sum_gen: for i in 0 to N-1 generate
+			out_A(i) <= prop_bits(i) XOR c_i_min1(i);		
+	end generate Sum_gen;
+	
+	
+
+end structural;

--- a/RTL/filters_and_routing/adders/ParalPrefix_Unit.vhd
+++ b/RTL/filters_and_routing/adders/ParalPrefix_Unit.vhd
@@ -1,0 +1,41 @@
+-- Copyright 2018 Stefania Preatto.
+-- Copyright and related rights are licensed under the Solderpad Hardware
+-- License, Version 0.51 (the “License”); you may not use this file except in
+-- compliance with the License.  You may obtain a copy of the License at
+-- http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+-- or agreed to in writing, software, hardware and materials distributed under
+-- this License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+----------------------------------------------------------------------------------
+-- Author: Stefania Preatto 
+-- 
+-- Create Date(mm/aaaa):	04/2018 
+-- Module Name:				ParalPrefix_Unit.vhd
+-- Project:					interpolation filter project for HEVC
+-- Description:				Parallel_Prefix_Adders
+-- Dependencies:			none
+--			
+-- Revision: 
+--		1.0 created
+----------------------------------------------------------------------------------
+
+library IEEE;
+use IEEE.std_logic_1164.all;
+use IEEE.numeric_std.all;
+
+entity ParalPrefix_Unit is
+	port(
+		G1,G0,P1,P0		:IN std_logic;	 -- adder inputs
+		G01,P01			:OUT std_logic  -- generate and propagate output
+	);
+end entity ParalPrefix_Unit;
+
+architecture structure of ParalPrefix_Unit is
+
+begin
+	
+	G01 <= G1 OR (P1 AND G0);
+	P01 <= P0 AND P1;
+	
+end structure;

--- a/RTL/filters_and_routing/chroma/filter_chroma_reconfigurable_stage2_LF_Correct.vhd
+++ b/RTL/filters_and_routing/chroma/filter_chroma_reconfigurable_stage2_LF_Correct.vhd
@@ -1,0 +1,148 @@
+-- Copyright 2017 Andrea Giannini.
+-- Copyright and related rights are licensed under the Solderpad Hardware
+-- License, Version 0.51 (the “License”); you may not use this file except in
+-- compliance with the License.  You may obtain a copy of the License at
+-- http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+-- or agreed to in writing, software, hardware and materials distributed under
+-- this License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+----------------------------------------------------------------------------------
+-- Author: Andrea Giannini 
+-- 
+-- Create Date(mm/aaaa):	09/2017 
+-- Module Name:			filter_chroma_reconfigurable_stage2.vhd
+-- Project:			interpolation filter project for HEVC
+-- Description:			4-tap reconfigurable multiplier-less 16-bit inputs filter, with configuration input vector
+-- Dependencies:		None
+--
+-- Revision: 
+--		Stefania Preatto
+----------------------------------------------------------------------------------
+library IEEE;
+use IEEE.std_logic_1164.all;
+use IEEE.numeric_std.all;
+
+entity filter_chroma_reconfigurable_stage2 is
+	port(
+		s0,s1,s2,s3:IN std_logic_vector(15 downto 0);	-- filter inputs
+		conf_vect:IN std_logic_vector(12 downto 0);	-- filter input configuration vector, see FSM2_filter.vhd for the different config settings
+		o:OUT std_logic_vector(21 downto 0)
+	);
+end entity filter_chroma_reconfigurable_stage2;
+
+architecture behavioural of filter_chroma_reconfigurable_stage2 is
+
+---------components
+
+component Ladner_Fisher_Nbit_correct is
+	generic(N:positive:=22);
+	port(
+		In1, In2			:IN std_logic_vector(N-1 downto 0);	-- adder inputs
+		out_A				:OUT std_logic_vector(N-1 downto 0)  -- adder output
+	);
+end component;
+
+---------signals
+	signal inA_op1,inB_op1:std_logic_vector(21 downto 0);
+	signal o_op1:std_logic_vector(21 downto 0);
+	signal inA_op2,inB_op2:std_logic_vector(19 downto 0);
+	signal o_op2:std_logic_vector(19 downto 0);
+	signal inA_op3,inB_op3:std_logic_vector(18 downto 0);
+	signal o_op3:std_logic_vector(18 downto 0);
+	signal inA_op4,inB_op4:std_logic_vector(16 downto 0);
+	signal o_op4:std_logic_vector(17 downto 0);
+	signal o_op5:std_logic_vector(21 downto 0);
+	signal o_op6:std_logic_vector(19 downto 0);
+	signal inB_op7:std_logic_vector(19 downto 0);
+	signal o_op7:std_logic_vector(19 downto 0);
+	signal inA_op3_ext,inB_op3_ext, o_op3_ext: std_logic_vector(19 downto 0);
+	
+	---added for approximate architecture
+	signal inA_op4_ext, inB_op4_ext: std_logic_vector(17 downto 0);
+	signal inA_op5, inB_op5			 : std_logic_vector(21 downto 0);
+	signal inA_op6, inB_op6			 : std_logic_vector(19 downto 0);
+	signal inA_op8, inB_op8			 : unsigned(21 downto 0);
+begin
+-- ADD op1
+inA_op1<=
+	s1(15)&s1&"00000" when conf_vect(12)='0' else	-- s1<<5
+	s1&"000000";					-- s1<<6
+inB_op1<=
+	s2(15)&s2&"00000" when conf_vect(11 downto 10)="00" else	-- s2<<5
+	s2(15)&s2(15)&s2&"0000" when conf_vect(11 downto 10)="01" else	-- s2<<4
+	s2(15)&s2(15)&s2(15)&s2&"000"; -- "10" or "11"			-- s2<<3
+	
+	A1: Ladner_Fisher_Nbit_correct port map (In1=>(inA_op1), In2=>(inB_op1), out_A=>o_op1);
+
+-- ADD op2
+inA_op2<=
+	s2(15)&s2(15)&s2(15)&s2&'0' when conf_vect(9 downto 8)="00" else	-- s2<<1
+	s2(15)&s2(15)&s2&"00" when conf_vect(9 downto 8)="01" else		-- s2<<2
+	std_logic_vector(to_unsigned(0,20));	-- when "10" or "11"		-- 0
+inB_op2<=
+	s1(15)&s1(15)&s1(15)&s1&'0' when conf_vect(7 downto 6)="00" else	-- s1<<1
+	s1&"0000" when conf_vect(7 downto 6)="01" else				-- s1<<4
+	s1(15)&s1(15)&s1&"00" when conf_vect(7 downto 6)="10" else		-- s1<<2
+	std_logic_vector(to_unsigned(0,20));			-- 0
+
+	A2: Ladner_Fisher_Nbit_correct generic map(N=>20)
+							port map (In1=>(inA_op2), In2=>(inB_op2), out_A=>o_op2);
+
+-- ADD op3
+inA_op3<=
+	s0(15)&s0&"00" when conf_vect(5)='0' else	-- s0<<2
+	s0(15)&s0(15)&s0&'0';				-- s0<<1
+inB_op3<=
+	s1&"000" when conf_vect(4)='0' else	-- s1<<3
+	s3(15)&s3&"00";				-- s3<<2
+	
+	inA_op3_ext <= '0'&inA_op3;
+	inB_op3_ext <= '0'&inB_op3;
+	A3: Ladner_Fisher_Nbit_correct generic map (N=>20)
+									port map (In1=>(inA_op3_ext), In2=>(inB_op3_ext), out_A=>o_op3_ext);
+	o_op3 <= o_op3_ext(18 downto 0);
+
+-- ADD op4
+inA_op4<=
+	s3&'0' when conf_vect(3 downto 2)="00" else			-- s3<<1
+	s0&'0' when conf_vect(3 downto 2)="01" else			-- s0<<1
+	std_logic_vector(to_unsigned(0,17));	-- when "10" or "11"	-- 0
+inB_op4<=
+	s1&'0' when conf_vect(1)='0' else	-- s1<<1
+	std_logic_vector(to_unsigned(0,17));	-- 0
+	
+inA_op4_ext <= inA_op4(16)&inA_op4;
+inB_op4_ext <= inB_op4(16)&inB_op4;
+
+	A4: Ladner_Fisher_Nbit_correct generic map (N=>18)
+								port map (In1=>(inA_op4_ext), In2=>(inB_op4_ext), out_A=>o_op4);
+
+-- ADD op5
+inA_op5 <= o_op1;
+inB_op5 <= o_op2(19)&o_op2(19)&o_op2;
+
+  A5: Ladner_Fisher_Nbit_correct
+								port map (In1=>(inA_op5), In2=>(inB_op5), out_A=>o_op5);
+
+-- ADD op6
+inA_op6 <= o_op3(18)&o_op3;
+inB_op6 <= o_op4(17)&o_op4(17)&o_op4;
+
+  A6: Ladner_Fisher_Nbit_correct generic map (N=>20)
+								port map (In1=>(inA_op6), In2=>(inB_op6), out_A=>o_op6);
+
+-- ADD op7
+inB_op7<=
+	s2(15)&s2(15)&s2&"00" when conf_vect(0)='0' else	-- s2<<2
+	std_logic_vector(to_unsigned(0,20));	-- 0
+
+	A7: Ladner_Fisher_Nbit_correct generic map (N=>20)
+								port map (In1=>(o_op6), In2=>(inB_op7), out_A=>o_op7);
+
+-- SUB op8
+inA_op8 <= unsigned(o_op5);
+inB_op8 <= unsigned(o_op7(19)&o_op7(19)&o_op7);
+o<=std_logic_vector(inA_op8-inB_op8);	-- discard carry out
+
+end architecture behavioural;

--- a/RTL/filters_and_routing/luma/filter_reconfigurable_3tap_stage2_HC_Correct.vhd
+++ b/RTL/filters_and_routing/luma/filter_reconfigurable_3tap_stage2_HC_Correct.vhd
@@ -1,0 +1,114 @@
+-- Copyright 2017 Andrea Giannini.
+-- Copyright and related rights are licensed under the Solderpad Hardware
+-- License, Version 0.51 (the “License”); you may not use this file except in
+-- compliance with the License.  You may obtain a copy of the License at
+-- http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+-- or agreed to in writing, software, hardware and materials distributed under
+-- this License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+----------------------------------------------------------------------------------
+-- Author: Andrea Giannini 
+-- 
+-- Create Date(mm/aaaa):	09/2017 
+-- Module Name:			filter_reconfigurable_3tap_stage2.vhd
+-- Project:			interpolation filter project for HEVC
+-- Description:			3-tap reconfigurable multiplier-less 16-bit inputs filter, with configuration input
+-- Dependencies:		None
+--
+-- Revision: 
+--		Stefania Preatto
+----------------------------------------------------------------------------------
+library IEEE;
+use IEEE.std_logic_1164.all;
+use IEEE.numeric_std.all;
+
+entity filter_reconfigurable_3tap_stage2 is
+	port(
+		in0,in1,in2:IN std_logic_vector(15 downto 0);	-- filter inputs
+		conf3:IN std_logic;				-- filter configuration input: '0' => half pixel filter, '1' => quarter pixel filter
+		o:OUT std_logic_vector(21 downto 0)
+	);
+end entity filter_reconfigurable_3tap_stage2;
+
+architecture behavioural of filter_reconfigurable_3tap_stage2 is
+
+--components
+component Han_Carlson_Correct_Adder_Nbits is
+	generic(N:positive:=22);
+	port(
+		In1, In2			:IN std_logic_vector(N-1 downto 0);	-- adder inputs
+		out_A				:OUT std_logic_vector(N-1 downto 0)  -- adder output
+	);
+end component;
+
+--signals
+	signal inA_op1,inB_op1:std_logic_vector(20 downto 0);
+	signal o_op1:std_logic_vector(21 downto 0);
+	signal inA_op2,inB_op2:std_logic_vector(20 downto 0);
+	signal o_op2:std_logic_vector(20 downto 0);
+	signal inA_op3,inB_op3:std_logic_vector(18 downto 0);
+	signal o_op3:std_logic_vector(18 downto 0);
+	signal o_op4:std_logic_vector(20 downto 0);
+	
+	signal inA_op1_ext, inB_op1_ext 				: std_logic_vector(21 downto 0);
+	signal inA_op2_ext, inB_op2_ext, o_op2_ext		: std_logic_vector(21 downto 0);
+	signal inA_op3_ext, inB_op3_ext, o_op3_ext		: std_logic_vector(19 downto 0);
+	signal inA_op5, inB_op5							: std_logic_vector(21 downto 0);
+	
+begin
+-- ADD op1
+inA_op1<=
+	in1&"00000" when conf3='0' else	-- in1<<5
+	in1(15)&in1&"0000";		-- in1<<4
+inB_op1<=
+	in2&"00000" when conf3='0' else	-- in2<<5
+	in2(15)&in2&"0000";			-- in2<<4
+	
+	inA_op1_ext <= inA_op1(20)&inA_op1;
+	inB_op1_ext <= inB_op1(20)&inB_op1;
+	A1: Han_Carlson_Correct_Adder_Nbits 
+					port map (In1=>(inA_op1_ext), In2=>(inB_op1_ext), out_A=>o_op1);
+	
+
+-- ADD op2
+inA_op2<=
+	in1(15)&in1(15)&in1&"000" when conf3='0' else	-- in1<<3
+	in1(15)&in1(15)&in1(15)&in1&"00";		-- in1<<2
+inB_op2<=
+	in1(15)&in1(15)&in1(15)&in1(15)&in1(15)&in1 when conf3='0' else		-- in1
+	in2&"00000";								-- in2<<5
+	
+	
+	inA_op2_ext <= '0'&inA_op2;
+	inB_op2_ext <= '0'&inB_op2;
+	A2: Han_Carlson_Correct_Adder_Nbits 
+					port map (In1=>(inA_op2_ext), In2=>(inB_op2_ext), out_A=>o_op2_ext);
+  o_op2 <= o_op2_ext(20 downto 0);
+
+-- ADD op3
+inA_op3<=
+	in0&"000" when conf3='0' else		-- in0<<3
+	in0(15)&in0&"00";			-- in0<<2
+inB_op3<=
+	in0(15)&in0(15)&in0(15)&in0 when conf3='0' else		-- in0
+	std_logic_vector(to_unsigned(0,19));			-- all 0
+
+	inA_op3_ext <= '0'&inA_op3;
+	inB_op3_ext <= '0'&inB_op3;
+	A3: Han_Carlson_Correct_Adder_Nbits generic map(N=>20)
+					port map (In1=>(inA_op3_ext), In2=>(inB_op3_ext), out_A=>o_op3_ext);
+  o_op3 <= o_op3_ext(18 downto 0);
+	
+
+-- SUB op4
+o_op4<=std_logic_vector(signed(o_op2)-signed(o_op3(18)&o_op3(18)&o_op3));	-- discard carry out
+
+-- ADD op5
+inA_op5 <= o_op1;
+inB_op5 <= o_op4(20)&o_op4;
+
+A5:  Han_Carlson_Correct_Adder_Nbits 
+					port map (In1=>(inA_op5), In2=>(inB_op5), out_A=>o);
+
+end architecture behavioural;

--- a/RTL/filters_and_routing/luma/filter_reconfigurable_5tap_stage2_HC_Correct.vhd
+++ b/RTL/filters_and_routing/luma/filter_reconfigurable_5tap_stage2_HC_Correct.vhd
@@ -1,0 +1,177 @@
+-- Copyright 2017 Andrea Giannini.
+-- Copyright and related rights are licensed under the Solderpad Hardware
+-- License, Version 0.51 (the “License”); you may not use this file except in
+-- compliance with the License.  You may obtain a copy of the License at
+-- http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+-- or agreed to in writing, software, hardware and materials distributed under
+-- this License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+----------------------------------------------------------------------------------
+-- Author: Andrea Giannini 
+-- 
+-- Create Date(mm/aaaa):	09/2017 
+-- Module Name:			filter_reconfigurable_5tap_stage2.vhd
+-- Project:				interpolation filter project for HEVC
+-- Description:			5-tap reconfigurable multiplier-less 16-bit inputs filter, with configuration input
+-- Dependencies:		Han_Carlson_Correct_Adder_Nbits.vhd
+--
+-- Revision: 
+--		Stefania Preatto
+----------------------------------------------------------------------------------
+library IEEE;
+use IEEE.std_logic_1164.all;
+use IEEE.numeric_std.all;
+
+entity filter_reconfigurable_5tap_stage2 is
+	port(
+		in0,in1,in2,in3,in4:IN std_logic_vector(15 downto 0);	-- filter inputs
+		conf5:IN std_logic;					-- filter configuration input: '0' => half pixel filter, '1' => quarter pixel filter
+		o:OUT std_logic_vector(21 downto 0)
+	);
+end entity filter_reconfigurable_5tap_stage2;
+
+architecture behavioural of filter_reconfigurable_5tap_stage2 is
+
+--components
+component Han_Carlson_Correct_Adder_Nbits is
+	generic(N:positive:=22);
+	port(
+		In1, In2			:IN std_logic_vector(N-1 downto 0);	-- adder inputs
+		out_A				:OUT std_logic_vector(N-1 downto 0)  -- adder output
+	);
+end component;
+
+--signals
+	signal inA_op1,inB_op1:std_logic_vector(16 downto 0);
+	signal o_op1: std_logic_vector(16 downto 0);
+	signal inA_op2,inB_op2:std_logic_vector(18 downto 0);
+	signal o_op2:std_logic_vector(18 downto 0);
+	signal inA_op3,inB_op3:std_logic_vector(20 downto 0);
+	signal o_op3:std_logic_vector(20 downto 0);
+	signal inA_op4,inB_op4:std_logic_vector(16 downto 0);
+	signal o_op4:std_logic_vector(16 downto 0);
+	signal inA_op5,inB_op5:std_logic_vector(18 downto 0);
+	signal o_op5:std_logic_vector(19 downto 0);
+	signal o_op6:std_logic_vector(18 downto 0);
+	signal inB_op7:std_logic_vector(20 downto 0);
+	signal o_op7:std_logic_vector(21 downto 0);
+	signal o_op9:std_logic_vector(19 downto 0);
+	signal o_op8:std_logic_vector(21 downto 0);
+	
+	signal inA_op1_ext, inB_op1_ext, o_op1_ext	: std_logic_vector(17 downto 0);
+	signal inA_op2_ext, inB_op2_ext, o_op2_ext	: std_logic_vector(19 downto 0);
+	signal inA_op3_ext, inB_op3_ext, o_op3_ext	: std_logic_vector(21 downto 0);
+	signal inA_op4_ext, inB_op4_ext, o_op4_ext	: std_logic_vector(17 downto 0);
+	signal inA_op5_ext, inB_op5_ext				: std_logic_vector(19 downto 0);
+	signal inA_op6, inB_op6, o_op6_ext			: std_logic_vector(19 downto 0);
+	signal inA_op7, inB_op7_ext					: std_logic_vector(21 downto 0);
+	signal inA_op8, inB_op8						: std_logic_vector(21 downto 0);
+	signal inA_op9, inB_op9						: std_logic_vector(19 downto 0);
+	
+begin
+
+-- ADD op1
+inA_op1<=
+	(others=>'0') when conf5='0' else	-- all 0
+	'0'&in0;				-- in0
+inB_op1<=
+	(others=>'0') when conf5='0' else	-- all 0
+	in3&'0';		-- in3<<1
+	
+	inA_op1_ext <= '0'&inA_op1;
+	inB_op1_ext <= '0'&inB_op1;
+	A1: Han_Carlson_Correct_Adder_Nbits generic map(N=>18)
+					port map (In1=>(inA_op1_ext), In2=>(inB_op1_ext), out_A=>o_op1_ext);
+	o_op1 <= o_op1_ext(16 downto 0);
+
+-- ADD op2
+inA_op2<=
+	in0(15)&in0(15)&in0&'0' when conf5='0' else	-- in0<<1
+	in2(15)&in2&"00";				-- in2<<2
+inB_op2<=
+	in2&"000" when conf5='0' else	-- in2<<3
+	in3(15)&in3&"00";				-- in3<<2
+	
+	inA_op2_ext <= '0'&inA_op2;
+	inB_op2_ext <= '0'&inB_op2;
+	A2: Han_Carlson_Correct_Adder_Nbits generic map(N=>20)
+					port map (In1=>(inA_op2_ext), In2=>(inB_op2_ext), out_A=>o_op2_ext);
+	o_op2 <= o_op2_ext(18 downto 0);
+
+-- ADD op3
+inA_op3<=
+	in2&"00000" when conf5='0' else	-- in2<<5
+	in2(15)&in2&"0000";			-- in2<<4
+inB_op3<=
+	in3(15)&in3(15)&in3&"000" when conf5='0' else	-- in3<<3
+	in3&"00000";				-- in3<<5
+
+	inA_op3_ext <= '0'&inA_op3;
+	inB_op3_ext <= '0'&inB_op3;
+	A3: Han_Carlson_Correct_Adder_Nbits 
+					port map (In1=>(inA_op3_ext), In2=>(inB_op3_ext), out_A=>o_op3_ext);
+	o_op3 <= o_op3_ext(20 downto 0);
+
+-- ADD op4
+inA_op4<=
+	in1(15)&in1 when conf5='0' else	-- in1
+	in1&'0';			-- in1<<1
+inB_op4<=in4(15)&in4;			-- in4
+	
+	inA_op4_ext <= '0'&inA_op4;
+	inB_op4_ext <= '0'&inB_op4;
+	A4: Han_Carlson_Correct_Adder_Nbits generic map(N=>18)
+					port map (In1=>(inA_op4_ext), In2=>(inB_op4_ext), out_A=>o_op4_ext);
+	o_op4 <= o_op4_ext(16 downto 0);
+
+-- ADD op5
+inA_op5<=
+	in1&"000" when conf5='0' else	-- in1<<3
+	in1(15)&in1&"00";			-- in1<<2
+inB_op5<=
+	in4&"000" when conf5='0' else	-- in4<<3
+	in4(15)&in4&"00";			-- in4<<2
+
+	inA_op5_ext <= inA_op5(18)&inA_op5;
+	inB_op5_ext <= inA_op5(18)&inB_op5;
+	A5: Han_Carlson_Correct_Adder_Nbits generic map(N=>20)
+					port map (In1=>(inA_op5_ext), In2=>(inB_op5_ext), out_A=>o_op5);
+
+
+-- ADD op6
+ inA_op6 <= '0'&o_op1(16)&o_op1(16)&o_op1;
+ inB_op6 <= '0'&o_op2;
+ 
+	A6: Han_Carlson_Correct_Adder_Nbits generic map(N=>20)
+					port map (In1=>(inA_op6), In2=>(inB_op6), out_A=>o_op6_ext);
+ 
+	o_op6 <= o_op6_ext(18 downto 0);
+
+-- ADD op7
+inB_op7<=
+	in3&"00000" when conf5='0' else	-- in3<<5
+	in3(15)&in3&"0000";			-- in3<<4
+	
+	inA_op7 <= o_op3(20)&o_op3;
+	inB_op7_ext <= inB_op7(20)&inB_op7;
+	A7: Han_Carlson_Correct_Adder_Nbits 
+					port map (In1=>(inA_op7), In2=>(inB_op7_ext), out_A=>o_op7);
+
+-- ADD op9
+inA_op9 <= o_op4(16)&o_op4(16)&o_op4(16)&o_op4;
+inB_op9 <= o_op5;
+   A9: Han_Carlson_Correct_Adder_Nbits generic map(N=>20)
+					port map (In1=>(inA_op9), In2=>(inB_op9), out_A=>o_op9);
+
+-- ADD op8
+inA_op8 <= o_op6(18)&o_op6(18)&o_op6(18)&o_op6;
+inB_op8 <= o_op7;
+   A8: Han_Carlson_Correct_Adder_Nbits 
+					port map (In1=>(inA_op8), In2=>(inB_op8), out_A=>o_op8);
+
+
+-- SUB op10
+o<=std_logic_vector(signed(o_op8)-signed(o_op9(19)&o_op9(19)&o_op9));	
+
+end architecture behavioural;

--- a/RTL/filters_and_routing/luma/filter_reconfigurable_stage2_GeAr.vhd
+++ b/RTL/filters_and_routing/luma/filter_reconfigurable_stage2_GeAr.vhd
@@ -1,0 +1,118 @@
+-- Copyright 2017 Andrea Giannini.
+-- Copyright and related rights are licensed under the Solderpad Hardware
+-- License, Version 0.51 (the “License”); you may not use this file except in
+-- compliance with the License.  You may obtain a copy of the License at
+-- http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+-- or agreed to in writing, software, hardware and materials distributed under
+-- this License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+----------------------------------------------------------------------------------
+-- Author: Andrea Giannini 
+-- 
+-- Create Date(mm/aaaa):	09/2017 
+-- Module Name:			filter_reconfigurable_stage2.vhd
+-- Project:				interpolation filter project for HEVC
+-- Description:			8/7-tap reconfigurable multiplier-less 16-bit inputs half filter, with configuration input vector
+-- Dependencies:		None
+--					GeAr_Adder_Nbits.vhd
+-- Revision: 
+--		Stefania Preatto
+----------------------------------------------------------------------------------
+library IEEE;
+use IEEE.std_logic_1164.all;
+use IEEE.numeric_std.all;
+
+entity filter_reconfigurable_stage2 is
+	port(
+		s0,s1,s2,s3:IN std_logic_vector(15 downto 0);	-- half filter inputs
+		conf_vect:IN std_logic_vector(8 downto 0);	-- half filter input configuration vector, see FSM2_filter.vhd for the different config settings
+		o:OUT std_logic_vector(21 downto 0)
+	);
+end entity filter_reconfigurable_stage2;
+
+architecture behavioural of filter_reconfigurable_stage2 is
+
+--components
+component GeAr_Adder_Nbits is
+	generic(N:integer:=22; R:integer:=7; P:integer:=0); -- L=R+P, N=R+L
+	port(
+		In1, In2			:IN std_logic_vector(N-1 downto 0);	-- adder inputs
+		c_in,c_in1			:IN std_logic;
+		c_out,c_out1		:OUT std_logic;
+		out_A				:OUT std_logic_vector(N-1 downto 0)  -- adder output
+	);
+end component;
+
+--signals
+	signal inA_op1,inB_op1,o_op1,inA_op2,inB_op2,o_op2,inA_op6,inB_op6,o_op6: std_logic_vector(21 downto 0);
+	signal inA_op5,inB_op5,o_op5,inA_op4,inB_op4,o_op4:std_logic_vector(18 downto 0);
+	signal o_op3:std_logic_vector(19 downto 0);
+	
+	--signal inA_op5_ext,inB_op5_ext,o_op5_ext:std_logic_vector(19 downto 0);
+	signal inA_op4_ext,inB_op4_ext,o_op4_ext,inA_op3,inB_op3:std_logic_vector(19 downto 0);
+	signal c_o_A1, c_o_A2, c_o_A4, c_o_A3: std_logic;
+	signal c_o1_A1, c_o1_A2, c_o1_A4, c_o1_A3: std_logic;
+	
+begin
+-- ADD op1
+inA_op1<=
+	s1(15)&s1(15)&s1(15)&s1(15)&s1&"00" when conf_vect(8)='0' else	-- s1<<2
+	s0(15)&s0(15)&s0(15)&s0(15)&s0(15)&s0(15)&s0;			-- s0
+inB_op1<=
+	s3(15)&s3&"00000" when conf_vect(7 downto 6)="00" else				-- s3<<5
+	s3&"000000" when conf_vect(7 downto 6)="01" else				-- s3<<6
+	s3(15)&s3(15)&s3(15)&s3(15)&s3(15)&s3&'0' when conf_vect(7 downto 6)="10" else	-- s3<<1
+	s2(15)&s2(15)&s2(15)&s2(15)&s2(15)&s2(15)&s2;					-- s2
+	
+	A1: GeAr_Adder_Nbits port map (In1=>(inA_op1), In2=>(inB_op1), c_in=>'0', c_in1=>'0', c_out=>c_o_A1, c_out1=>c_o1_A1, out_A=>o_op1);
+
+-- ADD op2
+inA_op2<=o_op1;
+inB_op2<=
+	s3(15)&s3(15)&s3(15)&s3&"000" when conf_vect(5 downto 4)="00" else		-- s3<<3
+	s3(15)&s3(15)&s3(15)&s3(15)&s3(15)&s3&'0' when conf_vect(5 downto 4)="01" else	-- s3<<1
+	s2(15)&s2(15)&s2&"0000";							-- s2<<4
+
+	A2: GeAr_Adder_Nbits port map (In1=>(inA_op2), In2=>(inB_op2), c_in=>c_o_A1, c_in1=>c_o1_A1, c_out=>c_o_A2, c_out1=>c_o1_A2, out_A=>o_op2);
+
+-- ADD op4
+inA_op4<=
+	s0(15)&s0(15)&s0(15)&s0 when conf_vect(3)='0' else	-- s0
+	s1(15)&s1(15)&s1(15)&s1;				-- s1
+inB_op4<=
+	s2&"000" when conf_vect(2)='0' else	-- s2<<3
+	s1(15)&s1&"00";			-- s1<<2
+	
+	inA_op4_ext <= '0'&inA_op4;
+	inB_op4_ext <= '0'&inB_op4;
+	A4:  GeAr_Adder_Nbits generic map (N=>20, R=>6)
+									port map (In1=>(inA_op4_ext), In2=>(inB_op4_ext),c_in=>'0',c_in1=>'0', c_out=>c_o_A4, c_out1=>c_o1_A4, out_A=>o_op4_ext);
+	
+	o_op4 <= o_op4_ext(18 downto 0);
+
+-- ADD op5
+inA_op5<=
+	s2(15)&s2(15)&s2&'0' when conf_vect(1)='0' else	-- s2<<1
+	std_logic_vector(to_unsigned(0,19));		-- 0
+inB_op5<=
+	s2(15)&s2(15)&s2(15)&s2 when conf_vect(0)<='0' else	-- s2
+	s3&"000";	-- s3<<3
+
+	o_op5 <= std_logic_vector(signed(inA_op5)+signed(inB_op5));
+
+-- ADD op3
+inA_op3<=o_op4(18)&o_op4;
+inB_op3<=o_op5(18)&o_op5;
+	A3: GeAr_Adder_Nbits generic map (N=>20, R=>6)
+									port map (In1=>(inA_op3), In2=>(inB_op3),c_in=>c_o_A4,c_in1=>c_o1_A4, c_out=>c_o_A3, c_out1=>c_o1_A3, out_A=>o_op3);
+
+-- SUB op6
+inA_op6<=o_op2;
+inB_op6<=o_op3(19)&o_op3(19)&o_op3;
+o_op6<=std_logic_vector(signed(inA_op6)-signed(inB_op6));
+
+o<=o_op6;
+
+end architecture behavioural;
+

--- a/RTL/filters_and_routing/luma/filter_reconfigurable_stage2_HC_Correct.vhd
+++ b/RTL/filters_and_routing/luma/filter_reconfigurable_stage2_HC_Correct.vhd
@@ -1,0 +1,117 @@
+-- Copyright 2017 Andrea Giannini.
+-- Copyright and related rights are licensed under the Solderpad Hardware
+-- License, Version 0.51 (the “License”); you may not use this file except in
+-- compliance with the License.  You may obtain a copy of the License at
+-- http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+-- or agreed to in writing, software, hardware and materials distributed under
+-- this License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR
+-- CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+----------------------------------------------------------------------------------
+-- Author: Andrea Giannini 
+-- 
+-- Create Date(mm/aaaa):	09/2017 
+-- Module Name:			filter_reconfigurable_stage2.vhd
+-- Project:			interpolation filter project for HEVC
+-- Description:			8/7-tap reconfigurable multiplier-less 16-bit inputs half filter, with configuration input vector
+-- Dependencies:		None
+--					Han_Carlson_Correct_Adder_Nbits.vhd
+-- Revision: 
+--		Stefania Preatto
+----------------------------------------------------------------------------------
+library IEEE;
+use IEEE.std_logic_1164.all;
+use IEEE.numeric_std.all;
+
+entity filter_reconfigurable_stage2 is
+	port(
+		s0,s1,s2,s3:IN std_logic_vector(15 downto 0);	-- half filter inputs
+		conf_vect:IN std_logic_vector(8 downto 0);	-- half filter input configuration vector, see FSM2_filter.vhd for the different config settings
+		o:OUT std_logic_vector(21 downto 0)
+	);
+end entity filter_reconfigurable_stage2;
+
+architecture behavioural of filter_reconfigurable_stage2 is
+
+--components
+component Han_Carlson_Correct_Adder_Nbits is
+	generic(N:positive:=22);
+	port(
+		In1, In2			:IN std_logic_vector(N-1 downto 0);	-- adder inputs
+		out_A				:OUT std_logic_vector(N-1 downto 0)  -- adder output
+	);
+end component;
+
+--signals
+	signal inA_op1,inB_op1,o_op1,inA_op2,inB_op2,o_op2,inA_op6,inB_op6,o_op6: std_logic_vector(21 downto 0);
+	signal inA_op5,inB_op5,o_op5,inA_op4,inB_op4,o_op4:std_logic_vector(18 downto 0);
+	signal o_op3:std_logic_vector(19 downto 0);
+	
+	signal inA_op5_ext,inB_op5_ext,inA_op4_ext,inB_op4_ext,o_op4_ext,o_op5_ext,inA_op3,inB_op3:std_logic_vector(19 downto 0);
+	
+begin
+-- ADD op1
+inA_op1<=
+	s1(15)&s1(15)&s1(15)&s1(15)&s1&"00" when conf_vect(8)='0' else	-- s1<<2
+	s0(15)&s0(15)&s0(15)&s0(15)&s0(15)&s0(15)&s0;			-- s0
+inB_op1<=
+	s3(15)&s3&"00000" when conf_vect(7 downto 6)="00" else				-- s3<<5
+	s3&"000000" when conf_vect(7 downto 6)="01" else				-- s3<<6
+	s3(15)&s3(15)&s3(15)&s3(15)&s3(15)&s3&'0' when conf_vect(7 downto 6)="10" else	-- s3<<1
+	s2(15)&s2(15)&s2(15)&s2(15)&s2(15)&s2(15)&s2;					-- s2
+	
+	A1: Han_Carlson_Correct_Adder_Nbits port map (In1=>(inA_op1), In2=>(inB_op1), out_A=>o_op1); 
+
+-- ADD op2
+inA_op2<=o_op1;
+inB_op2<=
+	s3(15)&s3(15)&s3(15)&s3&"000" when conf_vect(5 downto 4)="00" else		-- s3<<3
+	s3(15)&s3(15)&s3(15)&s3(15)&s3(15)&s3&'0' when conf_vect(5 downto 4)="01" else	-- s3<<1
+	s2(15)&s2(15)&s2&"0000";							-- s2<<4
+
+	A2: Han_Carlson_Correct_Adder_Nbits port map (In1=>(inA_op2), In2=>(inB_op2), out_A=>o_op2); 
+
+-- ADD op4
+inA_op4<=
+	s0(15)&s0(15)&s0(15)&s0 when conf_vect(3)='0' else	-- s0
+	s1(15)&s1(15)&s1(15)&s1;				-- s1
+inB_op4<=
+	s2&"000" when conf_vect(2)='0' else	-- s2<<3
+	s1(15)&s1&"00";			-- s1<<2
+	
+	inA_op4_ext <= '0'&inA_op4;
+	inB_op4_ext <= '0'&inB_op4;
+	A4:  Han_Carlson_Correct_Adder_Nbits generic map (N=>20)
+									port map (In1=>(inA_op4_ext), In2=>(inB_op4_ext), out_A=>o_op4_ext);
+	o_op4 <= o_op4_ext(18 downto 0);	
+
+-- ADD op5
+inA_op5<=
+	s2(15)&s2(15)&s2&'0' when conf_vect(1)='0' else	-- s2<<1
+	std_logic_vector(to_unsigned(0,19));		-- 0
+inB_op5<=
+	s2(15)&s2(15)&s2(15)&s2 when conf_vect(0)<='0' else	-- s2
+	s3&"000";	-- s3<<3
+
+	inA_op5_ext <= '0'&inA_op5;
+	inB_op5_ext <= '0'&inB_op5;
+	A5:  Han_Carlson_Correct_Adder_Nbits generic map (N=>20)
+									port map (In1=>(inA_op5_ext), In2=>(inB_op5_ext), out_A=>o_op5_ext);
+										
+	o_op5 <= o_op5_ext(18 downto 0);
+
+-- ADD op3
+inA_op3<=o_op4(18)&o_op4;
+inB_op3<=o_op5(18)&o_op5;
+	A3: Han_Carlson_Correct_Adder_Nbits generic map (N=>20)
+									port map (In1=>(inA_op3), In2=>(inB_op3), out_A=>o_op3);
+
+
+-- SUB op6
+inA_op6<=o_op2;
+inB_op6<=o_op3(19)&o_op3(19)&o_op3;
+o_op6<=std_logic_vector(signed(inA_op6)-signed(inB_op6));
+
+o<=o_op6;
+
+end architecture behavioural;


### PR DESCRIPTION
Several options for finding an appropriate internal structure for the adders involved in the filtering process are explored in order to further enhance the architecture in speed. 
Concerning the Chroma Legacy architecture, parallel & prefix correct adders configuration that employs a Ladner-Fischer prefix-processing stage results the most convenient choice in terms of speed
enhancement, at the cost of a negligible area overhead and power dissipation. As regards the
Luma Legacy architecture, the adoption of an approximate solution involving Generic Accuracy Configurable Adders is proposed: this results in a good trade-off between performances and precision at the entire HEVC system level.
Other options are applied to the DCT-IF Approximate architecture. For the Luma Approximate structure, a slight speed improvement with a reduction in power and occupied area is earned through the employment of Han-Carlson parallel & prefix correct adders, while for the Chroma Approximate architecture the starting structure is maintained.
